### PR TITLE
Settings sourceType parser option to module

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ module.exports = {
     "parserOptions": {
         "ecmaFeatures": {
             "jsx": true
-        }
+        },
+	"sourceType": "module"
     },
     "plugins": [
         "react"


### PR DESCRIPTION
To relax validation errors that are not applicable to ES6 modules, specifically, the need to manually activate strict mode.
http://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-code