### PR TITLE
Modifying rules to cohabitate with prettier rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ module.exports = {
         "no-underscore-dangle": "off",
         "no-unneeded-ternary": "error",
         "no-whitespace-before-property": "error",
-        "object-curly-newline": ["error", { "multiline": true }],
+        "object-curly-newline": ["error", { "consistent": true }],
         "object-curly-spacing": ["error", "always"],
         "object-property-newline": [
             "error", {
@@ -256,7 +256,7 @@ module.exports = {
         "quote-props": ["error", "consistent-as-needed"],
         "semi": [
             "error",
-            "never"
+            "always"
         ],
         "semi-spacing": "error",
         "space-before-blocks": ["error", "always"],

--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ module.exports = {
         "linebreak-style": ["error", process.platform === "win32" ? "windows" : "unix"],
         "lines-around-directive": ["error", "always"],
         "max-len": [
-            "warn", 100, {
+            "warn", 120, {
                 "ignoreComments": true,
                 "ignoreUrls": true,
                 "ignoreRegExpLiterals": true,


### PR DESCRIPTION
- Prettier adds semicolons at the end of lines, so changing the eslint "semi" rule to match.
- Prettier formats object definition style based on available line space, so changing the object-curly-newline rule to match.

-----

I noticed that eslint was failing to enforce some syntax rules in our codebase and I found the cause to be the inclusion of `prettier` rules which were overriding eslint. In order to let our specific eslint rules flow through, I have updated the rules which conflict with prettier so we can give our custom rules precedence.