### PR TITLE
Adding rule to enforce padding block statements with whitespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -247,8 +247,14 @@ module.exports = {
         "one-var": ["error", { "initialized": "never" }],
         "operator-assignment": "off",
         "operator-linebreak": "off",
-        //"padded-blocks": ["error", "never"],
         "padded-blocks": "off",
+        "padding-line-between-statements": [
+            "warn",
+            { blankLine: 'always', prev: '*', next: 'block' },
+            { blankLine: 'always', prev: 'block', next: '*' },
+            { blankLine: 'always', prev: '*', next: 'block-like' },
+            { blankLine: 'always', prev: 'block-like', next: '*' },
+        ],
         "quotes": [
             "error",
             "single"


### PR DESCRIPTION
Adding rule to enforce padding block statements with whitespace.

Syntax in violation after this rule takes effect:
```
let blahHandled = false;
if (blah) {
    handleBlah();
}
blahHandled = true;
```

Correct syntax after this rule takes effect:
```
let blahHandled = false;

if (blah) {
    handleBlah();
}

blahHandled = true;
```